### PR TITLE
Enable local variables

### DIFF
--- a/camunda/client/external_task_client.py
+++ b/camunda/client/external_task_client.py
@@ -51,12 +51,13 @@ class ExternalTaskClient:
             })
         return topics
 
-    def complete(self, task_id, variables):
+    def complete(self, task_id, global_variables, local_variables={}):
         url = self.get_task_complete_url(task_id)
 
         body = {
             "workerId": self.worker_id,
-            "variables": Variables.format(variables),
+            "variables": Variables.format(global_variables),
+            "localVariables": Variables.format(local_variables)
         }
 
         resp = requests.post(url, headers=self._get_headers(), json=body)

--- a/camunda/external_task/external_task_executor.py
+++ b/camunda/external_task/external_task_executor.py
@@ -40,12 +40,14 @@ class ExternalTaskExecutor:
 
     def _handle_task_success(self, task_id, task_result, topic):
         self._log_with_context(f"Marking task complete for Topic: {topic}", task_id)
-        if self.external_task_client.complete(task_id, task_result.variables):
+        if self.external_task_client.complete(task_id, task_result.global_variables, task_result.local_variables):
             self._log_with_context(f"Marked task completed - Topic: {topic} "
-                                   f"variables: {task_result.variables}", task_id)
+                                   f"global_variables: {task_result.global_variables} "
+                                   f"local_variables: {task_result.local_variables}", task_id)
         else:
             self._log_with_context(f"Not able to mark task completed - Topic: {topic} "
-                                   f"variables: {task_result.variables}", task_id)
+                                   f"global_variables: {task_result.global_variables} "
+                                   f"local_variables: {task_result.local_variables}", task_id)
             raise Exception(f"Not able to mark complete for task_id={task_id} "
                             f"for topic={topic}, worker_id={self.worker_id}")
 


### PR DESCRIPTION
This PR adds the feature of passing local variables to the Camunda engine. Additionally, it makes passing variables to "ExternalTask.complete" optional. It currently lacks additional unit tests but the ones that are available pass. Are you interested in this, @yogeshrnaik?