### PR TITLE
Handle already correct formatted variables in Variables.format

### DIFF
--- a/camunda/variables/tests/test_variables.py
+++ b/camunda/variables/tests/test_variables.py
@@ -28,6 +28,14 @@ class VariablesTest(TestCase):
                               "var2": {"value": True},
                               "var3": {"value": "string"}}, formatted_vars)
 
+    def test_format_returns_formatted_variables_keeps_already_formatted(self):
+        variables = {"var1": 1, "var2": True, "var3": "string", "var4": {"value": 1}}
+        formatted_vars = Variables.format(variables)
+        self.assertDictEqual({"var1": {"value": 1},
+                              "var2": {"value": True},
+                              "var3": {"value": "string"},
+                              "var4": {"value": 1}}, formatted_vars)
+
     def test_to_dict_returns_variables_as_dict(self):
         variables = Variables({"var1": {"value": 1},
                                "var2": {"value": True},

--- a/camunda/variables/variables.py
+++ b/camunda/variables/variables.py
@@ -21,7 +21,10 @@ class Variables:
         """
         formatted_vars = {}
         if variables:
-            formatted_vars = {k: {"value": v} for k, v in variables.items()}
+            formatted_vars = {
+                k: v if isinstance(v, dict) else {"value": v}
+                for k, v in variables.items()
+            }
         return formatted_vars
 
     def to_dict(self):


### PR DESCRIPTION
This change ensures that already correct formatted variables would not become wrapped again.