### PR TITLE
add method get_process_instance_variable to EngineClient

### DIFF
--- a/camunda/client/engine_client.py
+++ b/camunda/client/engine_client.py
@@ -1,3 +1,4 @@
+import base64
 import logging
 from http import HTTPStatus
 
@@ -133,3 +134,20 @@ class EngineClient:
         response = requests.put(url, headers=self._get_headers(), json=body)
         raise_exception_if_not_ok(response)
         return response.status_code == HTTPStatus.NO_CONTENT
+
+    def get_process_instance_variable(self, process_instance_id, variable_name, withmeta=False):
+        url = f"{self.engine_base_url}/process-instance/{process_instance_id}/variables/{variable_name}"
+        response = requests.get(url, headers=self._get_headers())
+        raise_exception_if_not_ok(response)
+        frame = response.json()
+
+        url_with_data = f"{url}/data"
+        response = requests.get(url_with_data, headers=self._get_headers())
+        raise_exception_if_not_ok(response)
+
+        decoded_value = base64.encodebytes(response.content).decode("utf-8")
+
+        if withmeta:
+            return dict(frame, value=decoded_value)
+        return decoded_value
+

--- a/camunda/client/engine_client.py
+++ b/camunda/client/engine_client.py
@@ -147,6 +147,6 @@ class EngineClient:
 
         decoded_value = base64.encodebytes(response.content).decode("utf-8")
 
-        if withmeta:
-            return dict(frame, value=decoded_value)
+        if with_meta:
+            return dict(resp_json, value=decoded_value)
         return decoded_value

--- a/camunda/client/engine_client.py
+++ b/camunda/client/engine_client.py
@@ -135,11 +135,11 @@ class EngineClient:
         raise_exception_if_not_ok(response)
         return response.status_code == HTTPStatus.NO_CONTENT
 
-    def get_process_instance_variable(self, process_instance_id, variable_name, withmeta=False):
+    def get_process_instance_variable(self, process_instance_id, variable_name, with_meta=False):
         url = f"{self.engine_base_url}/process-instance/{process_instance_id}/variables/{variable_name}"
         response = requests.get(url, headers=self._get_headers())
         raise_exception_if_not_ok(response)
-        frame = response.json()
+        resp_json = response.json()
 
         url_with_data = f"{url}/data"
         response = requests.get(url_with_data, headers=self._get_headers())
@@ -150,4 +150,3 @@ class EngineClient:
         if withmeta:
             return dict(frame, value=decoded_value)
         return decoded_value
-

--- a/camunda/client/tests/test_engine_client.py
+++ b/camunda/client/tests/test_engine_client.py
@@ -196,7 +196,7 @@ class EngineClientTest(TestCase):
         self.assertEqual(f"received 400 : RestException : {expected_message}", str(exception_ctx.exception))
 
     @responses.activate
-    def test_get_process_instance_variable_without_withmeta(self):
+    def test_get_process_instance_variable_without_meta(self):
         process_instance_id = "c2c68785-9f42-11ea-a841-0242ac1c0004"
         variable_name = "var1"
         process_instance_var_url = f"{ENGINE_LOCAL_BASE_URL}/process-instance/{process_instance_id}/variables/{variable_name}"
@@ -211,7 +211,7 @@ class EngineClientTest(TestCase):
         self.assertEqual("hellocamunda\n", resp)
 
     @responses.activate
-    def test_get_process_instance_variable_without_withmeta(self):
+    def test_get_process_instance_variable_with_meta(self):
         process_instance_id = "c2c68785-9f42-11ea-a841-0242ac1c0004"
         variable_name = "var1"
         process_instance_var_url = f"{ENGINE_LOCAL_BASE_URL}/process-instance/{process_instance_id}/variables/{variable_name}"

--- a/camunda/client/tests/test_engine_client.py
+++ b/camunda/client/tests/test_engine_client.py
@@ -1,3 +1,4 @@
+import base64
 from http import HTTPStatus
 from unittest import TestCase
 from unittest.mock import patch
@@ -193,3 +194,33 @@ class EngineClientTest(TestCase):
             self.client.correlate_message(message_name="XXX")
 
         self.assertEqual(f"received 400 : RestException : {expected_message}", str(exception_ctx.exception))
+
+    @responses.activate
+    def test_get_process_instance_variable_without_withmeta(self):
+        process_instance_id = "c2c68785-9f42-11ea-a841-0242ac1c0004"
+        variable_name = "var1"
+        process_instance_var_url = f"{ENGINE_LOCAL_BASE_URL}/process-instance/{process_instance_id}/variables/{variable_name}"
+        resp_frame_payload = {"value": None, "valueInfo": {}, "type": ""}
+        resp_data_payload = base64.decodebytes("hellocamunda".encode())
+        process_instance_var_data_url = f"{process_instance_var_url}/data"
+
+        responses.add(responses.GET, process_instance_var_url, status=HTTPStatus.OK, json=resp_frame_payload)
+        responses.add(responses.GET, process_instance_var_data_url, status=HTTPStatus.OK, body=resp_data_payload)
+
+        resp = self.client.get_process_instance_variable(process_instance_id, variable_name)
+        self.assertEqual("hellocamunda\n", resp)
+
+    @responses.activate
+    def test_get_process_instance_variable_without_withmeta(self):
+        process_instance_id = "c2c68785-9f42-11ea-a841-0242ac1c0004"
+        variable_name = "var1"
+        process_instance_var_url = f"{ENGINE_LOCAL_BASE_URL}/process-instance/{process_instance_id}/variables/{variable_name}"
+        resp_frame_payload = {"value": None, "valueInfo": {}, "type": ""}
+        resp_data_payload = base64.decodebytes("hellocamunda".encode())
+        process_instance_var_data_url = f"{process_instance_var_url}/data"
+
+        responses.add(responses.GET, process_instance_var_url, status=HTTPStatus.OK, json=resp_frame_payload)
+        responses.add(responses.GET, process_instance_var_data_url, status=HTTPStatus.OK, body=resp_data_payload)
+
+        resp = self.client.get_process_instance_variable(process_instance_id, variable_name, True)
+        self.assertEqual({"value": "hellocamunda\n", "valueInfo": {}, "type": ""}, resp)


### PR DESCRIPTION
This change adds a new method "get_process_instance_variable" to the engine-client. With this it is possible to get the content of File or Bytes variables which is not transferred with fetchAndLock.