### PR TITLE
strip long variables before logging values

### DIFF
--- a/camunda/external_task/external_task_executor.py
+++ b/camunda/external_task/external_task_executor.py
@@ -42,7 +42,7 @@ class ExternalTaskExecutor:
             return variables
         cleaned = {}
         for k, v in variables.items():
-            if isinstance(v, dict) and v.get("type", "") in ("File", "Bytes", "Json"):
+            if isinstance(v, dict) and v.get("type", "") in ("File", "Bytes"):
                 cleaned[k] = {**v, "value": "..."}
             else:
                 cleaned[k] = v

--- a/camunda/external_task/tests/test_external_task_executor.py
+++ b/camunda/external_task/tests/test_external_task_executor.py
@@ -1,3 +1,4 @@
+import base64
 import collections
 from http import HTTPStatus
 from unittest import TestCase
@@ -141,3 +142,22 @@ class ExternalTaskExecutorTest(TestCase):
                     executor.execute_task(task, task_result_test.task_action)
 
                 self.assertEqual(task_result_test.expected_error_message, str(exception_ctx.exception))
+
+    def test_strip_long_variables(self):
+        variables = {
+            "var0": "string",
+            "var1": {"value": "string"}, 
+            "var2": {"value": 1}, 
+            "var3": {"value": "{\"key\": \"value\"}", "type": "Json"},
+            "var4": {"value": base64.encodebytes(b"string"), "type": "Bytes"},
+            "var5": {"value": "some file content", "type": "File"},
+        }
+        cleaned = ExternalTaskExecutor._strip_long_variables(None, variables)
+        self.assertEqual({
+            "var0": "string",
+            "var1": {"value": "string"}, 
+            "var2": {"value": 1}, 
+            "var3": {"value": "...", "type": "Json"},
+            "var4": {"value": "...", "type": "Bytes"},
+            "var5": {"value": "...", "type": "File"},
+        }, cleaned)

--- a/camunda/external_task/tests/test_external_task_executor.py
+++ b/camunda/external_task/tests/test_external_task_executor.py
@@ -146,8 +146,8 @@ class ExternalTaskExecutorTest(TestCase):
     def test_strip_long_variables(self):
         variables = {
             "var0": "string",
-            "var1": {"value": "string"}, 
-            "var2": {"value": 1}, 
+            "var1": {"value": "string"},
+            "var2": {"value": 1},
             "var3": {"value": "{\"key\": \"value\"}", "type": "Json"},
             "var4": {"value": base64.encodebytes(b"string"), "type": "Bytes"},
             "var5": {"value": "some file content", "type": "File"},
@@ -155,9 +155,9 @@ class ExternalTaskExecutorTest(TestCase):
         cleaned = ExternalTaskExecutor._strip_long_variables(None, variables)
         self.assertEqual({
             "var0": "string",
-            "var1": {"value": "string"}, 
-            "var2": {"value": 1}, 
-            "var3": {"value": "...", "type": "Json"},
+            "var1": {"value": "string"},
+            "var2": {"value": 1},
+            "var3": {"value": "{\"key\": \"value\"}", "type": "Json"},
             "var4": {"value": "...", "type": "Bytes"},
             "var5": {"value": "...", "type": "File"},
         }, cleaned)


### PR DESCRIPTION
This change strips longs content of File, Bytes or Json variables before logging them. This ensures clean logging and does not overload it with long json or base64.