### PR TITLE
Dev 4.0.1

### DIFF
--- a/camunda/client/external_task_client.py
+++ b/camunda/client/external_task_client.py
@@ -21,7 +21,7 @@ class ExternalTaskClient:
         "retryTimeout": 300000,
         "httpTimeoutMillis": 30000,
         "timeoutDeltaMillis": 5000,
-        "includeExtensionProperties": True
+        "includeExtensionProperties": True  # enables Camunda Extension Properties
     }
 
     def __init__(self, worker_id, engine_base_url=ENGINE_LOCAL_BASE_URL, config=None):
@@ -68,6 +68,7 @@ class ExternalTaskClient:
                 "topicName": topic,
                 "lockDuration": self.config["lockDuration"],
                 "processVariables": process_variables if process_variables else {},
+                # enables Camunda Extension Properties
                 "includeExtensionProperties": self.config["includeExtensionProperties"]
                 if "includeExtensionProperties" in self.config else False
 

--- a/camunda/client/external_task_client.py
+++ b/camunda/client/external_task_client.py
@@ -69,8 +69,7 @@ class ExternalTaskClient:
                 "lockDuration": self.config["lockDuration"],
                 "processVariables": process_variables if process_variables else {},
                 # enables Camunda Extension Properties
-                "includeExtensionProperties": self.config["includeExtensionProperties"]
-                if "includeExtensionProperties" in self.config else False
+                "includeExtensionProperties": self.config.get("includeExtensionProperties") or False
 
             })
         return topics

--- a/camunda/client/external_task_client.py
+++ b/camunda/client/external_task_client.py
@@ -21,6 +21,7 @@ class ExternalTaskClient:
         "retryTimeout": 300000,
         "httpTimeoutMillis": 30000,
         "timeoutDeltaMillis": 5000,
+        "includeExtensionProperties": True
     }
 
     def __init__(self, worker_id, engine_base_url=ENGINE_LOCAL_BASE_URL, config=None):
@@ -66,7 +67,10 @@ class ExternalTaskClient:
             topics.append({
                 "topicName": topic,
                 "lockDuration": self.config["lockDuration"],
-                "processVariables": process_variables if process_variables else {}
+                "processVariables": process_variables if process_variables else {},
+                "includeExtensionProperties": self.config["includeExtensionProperties"]
+                if "includeExtensionProperties" in self.config else False
+
             })
         return topics
 

--- a/camunda/external_task/external_task.py
+++ b/camunda/external_task/external_task.py
@@ -1,3 +1,4 @@
+from camunda.variables.properties import Properties
 from camunda.variables.variables import Variables
 
 
@@ -7,6 +8,7 @@ class ExternalTask:
         self._context = context
         self._variables = Variables(context.get("variables", {}))
         self._task_result = TaskResult.empty_task_result(task=self)
+        self._extProperties = Properties(context.get("extensionProperties", {}))
 
     def get_worker_id(self):
         return self._context["workerId"]
@@ -16,6 +18,9 @@ class ExternalTask:
 
     def get_variables(self):
         return self._variables.to_dict()
+
+    def get_extension_properties(self) -> dict:
+        return self._extProperties.to_dict()
 
     def get_task_id(self):
         return self._context["id"]
@@ -28,6 +33,9 @@ class ExternalTask:
 
     def get_variable(self, variable_name):
         return self._variables.get_variable(variable_name)
+
+    def get_extension_property(self, property_name) -> str:
+        return self._extProperties.get_property(property_name)
 
     def get_tenant_id(self):
         return self._context.get("tenantId", None)

--- a/camunda/external_task/tests/test_external_task.py
+++ b/camunda/external_task/tests/test_external_task.py
@@ -87,9 +87,9 @@ class ExternalTaskTest(TestCase):
         self.assertEqual(1, variable)
 
     def test_get_property_returns_value_for_property_present(self):
-        task = ExternalTask(context={"extensionProperties": {"var_name": {"value": 1}}})
-        prop = task.get_extension_property("var_name")
-        self.assertEqual(1, prop)
+        task = ExternalTask(context={"extensionProperties":  {"var1":"one","var2":"two"}})
+        prop = task.get_extension_property("var1")
+        self.assertEqual("one", prop)
 
     def test_str(self):
         task = ExternalTask(context={"variables": {"var_name": {"value": 1}}})

--- a/camunda/external_task/tests/test_external_task.py
+++ b/camunda/external_task/tests/test_external_task.py
@@ -86,6 +86,11 @@ class ExternalTaskTest(TestCase):
         variable = task.get_variable("var_name")
         self.assertEqual(1, variable)
 
+    def test_get_property_returns_value_for_property_present(self):
+        task = ExternalTask(context={"extensionProperties": {"var_name": {"value": 1}}})
+        prop = task.get_extension_property("var_name")
+        self.assertEqual(1, prop)
+
     def test_str(self):
         task = ExternalTask(context={"variables": {"var_name": {"value": 1}}})
         self.assertEqual("{'variables': {'var_name': {'value': 1}}}", str(task))

--- a/camunda/variables/properties.py
+++ b/camunda/variables/properties.py
@@ -1,21 +1,29 @@
 class Properties:
+    """
+    Properties are key->value pairs which acts as a kind of constant in Camunda.
+    A property can be set via Camunda Modeller's Properties Panel on the Extension tab.
+
+    Properties appear in a ExternalTask as soon as the config for an ExternalTaskClient will
+    have a configuration includeExtensionProperties: True (which is the default)
+
+    Properties will store strings only.
+    """
     def __init__(self, properties={}):
         self.properties = properties
 
-    def get_property(self, property_name):
+    def get_property(self, property_name) -> str:
+        """
+        access a single property
+        """
         prop = self.properties.get(property_name, None)
         if not prop:
             return None
 
         return prop
 
-    def to_dict(self):
+    def to_dict(self) -> dict:
         """
         Converts the properties to a simple dictionary
-        :return: dict
-            {"var1": {"value": 1}, "var2": {"value": True}}
-            ->
-            {"var1": 1, "var2": True}
         """
         result = {}
         for k, v in self.properties.items():

--- a/camunda/variables/properties.py
+++ b/camunda/variables/properties.py
@@ -15,11 +15,7 @@ class Properties:
         """
         access a single property
         """
-        prop = self.properties.get(property_name, None)
-        if not prop:
-            return None
-
-        return prop
+        return self.properties.get(property_name, None)
 
     def to_dict(self) -> dict:
         """

--- a/camunda/variables/properties.py
+++ b/camunda/variables/properties.py
@@ -19,5 +19,5 @@ class Properties:
         """
         result = {}
         for k, v in self.properties.items():
-            result[k] = v["value"]
+            result[k] = v
         return result

--- a/camunda/variables/properties.py
+++ b/camunda/variables/properties.py
@@ -7,7 +7,7 @@ class Properties:
         if not prop:
             return None
 
-        return prop["value"]
+        return prop
 
     def to_dict(self):
         """

--- a/camunda/variables/properties.py
+++ b/camunda/variables/properties.py
@@ -1,0 +1,23 @@
+class Properties:
+    def __init__(self, properties={}):
+        self.properties = properties
+
+    def get_property(self, property_name):
+        prop = self.properties.get(property_name, None)
+        if not prop:
+            return None
+
+        return prop["value"]
+
+    def to_dict(self):
+        """
+        Converts the properties to a simple dictionary
+        :return: dict
+            {"var1": {"value": 1}, "var2": {"value": True}}
+            ->
+            {"var1": 1, "var2": True}
+        """
+        result = {}
+        for k, v in self.properties.items():
+            result[k] = v["value"]
+        return result

--- a/camunda/variables/tests/test_properties.py
+++ b/camunda/variables/tests/test_properties.py
@@ -1,0 +1,20 @@
+from unittest import TestCase
+
+from camunda.variables.properties import Properties
+
+
+class PropertiesTest(TestCase):
+
+    def test_get_variable_returns_none_when_variable_absent(self):
+        properties = Properties({})
+        self.assertIsNone(properties.get_property("var1"))
+
+    def test_get_variable_returns_value_when_variable_present(self):
+        properties = Properties({"var1": {"value": 1}})
+        self.assertEqual(1, properties.get_property("var1"))
+
+    def test_to_dict_returns_variables_as_dict(self):
+        properties = Properties({"var1": {"value": 1},
+                                "var2": {"value": True},
+                                "var3": {"value": "string"}})
+        self.assertDictEqual({"var1": 1, "var2": True, "var3": "string"}, properties.to_dict())

--- a/camunda/variables/tests/test_properties.py
+++ b/camunda/variables/tests/test_properties.py
@@ -10,11 +10,11 @@ class PropertiesTest(TestCase):
         self.assertIsNone(properties.get_property("var1"))
 
     def test_get_variable_returns_value_when_variable_present(self):
-        properties = Properties({"var1": {"value": 1}})
+        properties = Properties({"var1": 1})
         self.assertEqual(1, properties.get_property("var1"))
 
     def test_to_dict_returns_variables_as_dict(self):
-        properties = Properties({"var1": {"value": 1},
-                                "var2": {"value": True},
-                                "var3": {"value": "string"}})
+        properties = Properties({"var1": 1,
+                                "var2": True,
+                                "var3": "string"})
         self.assertDictEqual({"var1": 1, "var2": True, "var3": "string"}, properties.to_dict())

--- a/camunda/variables/tests/test_properties.py
+++ b/camunda/variables/tests/test_properties.py
@@ -10,11 +10,11 @@ class PropertiesTest(TestCase):
         self.assertIsNone(properties.get_property("var1"))
 
     def test_get_variable_returns_value_when_variable_present(self):
-        properties = Properties({"var1": 1})
-        self.assertEqual(1, properties.get_property("var1"))
+        properties = Properties({"var1": "one"})
+        self.assertEqual("one", properties.get_property("var1"))
 
     def test_to_dict_returns_variables_as_dict(self):
-        properties = Properties({"var1": 1,
-                                "var2": True,
-                                "var3": "string"})
-        self.assertDictEqual({"var1": 1, "var2": True, "var3": "string"}, properties.to_dict())
+        properties = Properties({"var1": "Sample1",
+                                 "var2": "Sample2",
+                                 "var3": "Sample3"})
+        self.assertDictEqual({"var1": "Sample1", "var2": "Sample2", "var3": "Sample3"}, properties.to_dict())


### PR DESCRIPTION
This small patch enables the Extension Properties from Camunda 7.15.
The interface description is here https://docs.camunda.org/manual/7.15/reference/rest/external-task/fetch/ (grep for "includeExtensionProperties" on this side)

The extension properties are reachable in the Camunda Modeller Tool as a tab in the Properties Panel. I use these properties to model a kind of constants in the workflow.

Interestingly, your code already works with properties, the only thing missing is the message to Camunda "send the properties" as part of a task. I also added some support stuff to simplify the access to these properties.

includeExtensionProperties=True means that the  properties will be sent by default for people who use the default config and won't be sent for older projects with an overridden configuration.